### PR TITLE
Add livesim mpd

### DIFF
--- a/fixture_livesim_vod.mpd
+++ b/fixture_livesim_vod.mpd
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<MPD xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="urn:mpeg:dash:schema:mpd:2011" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" type="static" mediaPresentationDuration="PT1H" minBufferTime="PT2S" maxSegmentDuration="PT2S" profiles="urn:mpeg:dash:profile:isoff-live:2011,http://dashif.org/guidelines/dash-if-simple">
+  <ProgramInformation>
+    <Title>Media Presentation Description from DASH-IF live simulator</Title>
+  </ProgramInformation>
+  <Period start="PT0S" id="precambrian">
+    <AdaptationSet contentType="audio" mimeType="audio/mp4" segmentAlignment="true" startWithSAP="1" lang="en">
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
+      <SegmentTemplate media="$RepresentationID$/$Number$.m4s" initialization="$RepresentationID$/init.mp4" duration="2" startNumber="1"/>
+      <Representation id="A48" bandwidth="48000" audioSamplingRate="48000" codecs="mp4a.40.2">
+        <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
+      </Representation>
+    </AdaptationSet>
+    <AdaptationSet contentType="video" mimeType="video/mp4" segmentAlignment="true" startWithSAP="1" par="16:9" minWidth="640" maxWidth="640" minHeight="360" maxHeight="360" maxFrameRate="60/2">
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
+      <SegmentTemplate media="$RepresentationID$/$Number$.m4s" initialization="$RepresentationID$/init.mp4" duration="2" startNumber="1"/>
+      <Representation id="V300" width="640" height="360" sar="1:1" frameRate="60/2" bandwidth="300000" codecs="avc1.64001e"/>
+    </AdaptationSet>
+  </Period>
+</MPD>

--- a/mpd.go
+++ b/mpd.go
@@ -70,6 +70,7 @@ type MPD struct {
 	AvailabilityStartTime      *string  `xml:"availabilityStartTime,attr"`
 	MediaPresentationDuration  *string  `xml:"mediaPresentationDuration,attr"`
 	MinBufferTime              *string  `xml:"minBufferTime,attr"`
+	MaxSegmentDuration         *string  `xml:"maxSegmentDuration,attr,omitempty"`
 	SuggestedPresentationDelay *string  `xml:"suggestedPresentationDelay,attr"`
 	TimeShiftBufferDepth       *string  `xml:"timeShiftBufferDepth,attr"`
 	PublishTime                *string  `xml:"publishTime,attr"`
@@ -94,6 +95,7 @@ type mpdMarshal struct {
 	AvailabilityStartTime      *string         `xml:"availabilityStartTime,attr"`
 	MediaPresentationDuration  *string         `xml:"mediaPresentationDuration,attr"`
 	MinBufferTime              *string         `xml:"minBufferTime,attr"`
+	MaxSegmentDuration         *string         `xml:"maxSegmentDuration,attr,omitempty"`
 	SuggestedPresentationDelay *string         `xml:"suggestedPresentationDelay,attr"`
 	TimeShiftBufferDepth       *string         `xml:"timeShiftBufferDepth,attr"`
 	Profiles                   string          `xml:"profiles,attr"`
@@ -268,6 +270,7 @@ func modifyMPD(mpd *MPD) *mpdMarshal {
 		AvailabilityStartTime:      copyobj.String(mpd.AvailabilityStartTime),
 		MediaPresentationDuration:  copyobj.String(mpd.MediaPresentationDuration),
 		MinBufferTime:              copyobj.String(mpd.MinBufferTime),
+		MaxSegmentDuration:         copyobj.String(mpd.MaxSegmentDuration),
 		SuggestedPresentationDelay: copyobj.String(mpd.SuggestedPresentationDelay),
 		TimeShiftBufferDepth:       copyobj.String(mpd.TimeShiftBufferDepth),
 		PublishTime:                copyobj.String(mpd.PublishTime),

--- a/mpd.go
+++ b/mpd.go
@@ -190,31 +190,33 @@ type adaptationSetMarshal struct {
 
 // Representation represents XSD's RepresentationType.
 type Representation struct {
-	ID                 *string          `xml:"id,attr"`
-	Width              *uint64          `xml:"width,attr"`
-	Height             *uint64          `xml:"height,attr"`
-	SAR                *string          `xml:"sar,attr"`
-	FrameRate          *string          `xml:"frameRate,attr"`
-	Bandwidth          *uint64          `xml:"bandwidth,attr"`
-	AudioSamplingRate  *string          `xml:"audioSamplingRate,attr"`
-	Codecs             *string          `xml:"codecs,attr"`
-	BaseURL            *string          `xml:"BaseURL,omitempty"`
-	ContentProtections []DRMDescriptor  `xml:"ContentProtection,omitempty"`
-	SegmentTemplate    *SegmentTemplate `xml:"SegmentTemplate,omitempty"`
+	ID                        *string                    `xml:"id,attr"`
+	Width                     *uint64                    `xml:"width,attr"`
+	Height                    *uint64                    `xml:"height,attr"`
+	SAR                       *string                    `xml:"sar,attr"`
+	FrameRate                 *string                    `xml:"frameRate,attr"`
+	Bandwidth                 *uint64                    `xml:"bandwidth,attr"`
+	AudioSamplingRate         *string                    `xml:"audioSamplingRate,attr"`
+	Codecs                    *string                    `xml:"codecs,attr"`
+	BaseURL                   *string                    `xml:"BaseURL,omitempty"`
+	ContentProtections        []DRMDescriptor            `xml:"ContentProtection,omitempty"`
+	SegmentTemplate           *SegmentTemplate           `xml:"SegmentTemplate,omitempty"`
+	AudioChannelConfiguration *AudioChannelConfiguration `xml:"AudioChannelConfiguration,omitempty"`
 }
 
 type representationMarshal struct {
-	ID                 *string                `xml:"id,attr"`
-	Width              *uint64                `xml:"width,attr"`
-	Height             *uint64                `xml:"height,attr"`
-	SAR                *string                `xml:"sar,attr"`
-	FrameRate          *string                `xml:"frameRate,attr"`
-	Bandwidth          *uint64                `xml:"bandwidth,attr"`
-	AudioSamplingRate  *string                `xml:"audioSamplingRate,attr"`
-	Codecs             *string                `xml:"codecs,attr"`
-	BaseURL            *string                `xml:"BaseURL,omitempty"`
-	ContentProtections []drmDescriptorMarshal `xml:"ContentProtection,omitempty"`
-	SegmentTemplate    *SegmentTemplate       `xml:"SegmentTemplate,omitempty"`
+	ID                        *string                    `xml:"id,attr"`
+	Width                     *uint64                    `xml:"width,attr"`
+	Height                    *uint64                    `xml:"height,attr"`
+	SAR                       *string                    `xml:"sar,attr"`
+	FrameRate                 *string                    `xml:"frameRate,attr"`
+	Bandwidth                 *uint64                    `xml:"bandwidth,attr"`
+	AudioSamplingRate         *string                    `xml:"audioSamplingRate,attr"`
+	Codecs                    *string                    `xml:"codecs,attr"`
+	BaseURL                   *string                    `xml:"BaseURL,omitempty"`
+	ContentProtections        []drmDescriptorMarshal     `xml:"ContentProtection,omitempty"`
+	SegmentTemplate           *SegmentTemplate           `xml:"SegmentTemplate,omitempty"`
+	AudioChannelConfiguration *AudioChannelConfiguration `xml:"AudioChannelConfiguration,omitempty"`
 }
 
 // Descriptor represents XSD's DescriptorType.
@@ -329,21 +331,32 @@ func modifyRepresentations(rs []Representation) []representationMarshal {
 	rsm := make([]representationMarshal, 0, len(rs))
 	for _, r := range rs {
 		representation := representationMarshal{
-			AudioSamplingRate:  copyobj.String(r.AudioSamplingRate),
-			Bandwidth:          copyobj.UInt64(r.Bandwidth),
-			Codecs:             copyobj.String(r.Codecs),
-			FrameRate:          copyobj.String(r.FrameRate),
-			Height:             copyobj.UInt64(r.Height),
-			ID:                 copyobj.String(r.ID),
-			Width:              copyobj.UInt64(r.Width),
-			SegmentTemplate:    copySegmentTemplate(r.SegmentTemplate),
-			SAR:                copyobj.String(r.SAR),
-			ContentProtections: modifyContentProtections(r.ContentProtections),
-			BaseURL:            copyobj.String(r.BaseURL),
+			AudioSamplingRate:         copyobj.String(r.AudioSamplingRate),
+			Bandwidth:                 copyobj.UInt64(r.Bandwidth),
+			Codecs:                    copyobj.String(r.Codecs),
+			FrameRate:                 copyobj.String(r.FrameRate),
+			Height:                    copyobj.UInt64(r.Height),
+			ID:                        copyobj.String(r.ID),
+			Width:                     copyobj.UInt64(r.Width),
+			SegmentTemplate:           copySegmentTemplate(r.SegmentTemplate),
+			SAR:                       copyobj.String(r.SAR),
+			ContentProtections:        modifyContentProtections(r.ContentProtections),
+			BaseURL:                   copyobj.String(r.BaseURL),
+			AudioChannelConfiguration: copyAudioChannelConfiguration(r.AudioChannelConfiguration),
 		}
 		rsm = append(rsm, representation)
 	}
 	return rsm
+}
+
+func copyAudioChannelConfiguration(acc *AudioChannelConfiguration) *AudioChannelConfiguration {
+	if acc == nil {
+		return nil
+	}
+	return &AudioChannelConfiguration{
+		SchemeIDURI: copyobj.String(acc.SchemeIDURI),
+		Value:       copyobj.String(acc.Value),
+	}
 }
 
 func copySegmentTemplate(st *SegmentTemplate) *SegmentTemplate {
@@ -396,4 +409,10 @@ func modifyPssh(p *Pssh) *psshMarshal {
 		Cenc:  copyobj.String(p.Cenc),
 		Value: copyobj.String(p.Value),
 	}
+}
+
+// AudioChannelConfiguration represents XSD's AudioChannelConfiguration type.
+type AudioChannelConfiguration struct {
+	SchemeIDURI *string `xml:"schemeIdUri,attr"`
+	Value       *string `xml:"value,attr,omitempty"`
 }

--- a/mpd.go
+++ b/mpd.go
@@ -63,44 +63,46 @@ var (
 
 // MPD represents root XML element for parse.
 type MPD struct {
-	XMLName                    xml.Name `xml:"MPD"`
-	XMLNS                      *string  `xml:"xmlns,attr"`
-	Type                       *string  `xml:"type,attr"`
-	MinimumUpdatePeriod        *string  `xml:"minimumUpdatePeriod,attr"`
-	AvailabilityStartTime      *string  `xml:"availabilityStartTime,attr"`
-	MediaPresentationDuration  *string  `xml:"mediaPresentationDuration,attr"`
-	MinBufferTime              *string  `xml:"minBufferTime,attr"`
-	MaxSegmentDuration         *string  `xml:"maxSegmentDuration,attr,omitempty"`
-	SuggestedPresentationDelay *string  `xml:"suggestedPresentationDelay,attr"`
-	TimeShiftBufferDepth       *string  `xml:"timeShiftBufferDepth,attr"`
-	PublishTime                *string  `xml:"publishTime,attr"`
-	Profiles                   string   `xml:"profiles,attr"`
-	XSI                        *string  `xml:"xsi,attr,omitempty"`
-	SCTE35                     *string  `xml:"scte35,attr,omitempty"`
-	XSISchemaLocation          *string  `xml:"schemaLocation,attr"`
-	ID                         *string  `xml:"id,attr"`
-	Period                     []Period `xml:"Period,omitempty"`
+	XMLName                    xml.Name            `xml:"MPD"`
+	XMLNS                      *string             `xml:"xmlns,attr"`
+	Type                       *string             `xml:"type,attr"`
+	MinimumUpdatePeriod        *string             `xml:"minimumUpdatePeriod,attr"`
+	AvailabilityStartTime      *string             `xml:"availabilityStartTime,attr"`
+	MediaPresentationDuration  *string             `xml:"mediaPresentationDuration,attr"`
+	MinBufferTime              *string             `xml:"minBufferTime,attr"`
+	MaxSegmentDuration         *string             `xml:"maxSegmentDuration,attr,omitempty"`
+	SuggestedPresentationDelay *string             `xml:"suggestedPresentationDelay,attr"`
+	TimeShiftBufferDepth       *string             `xml:"timeShiftBufferDepth,attr"`
+	PublishTime                *string             `xml:"publishTime,attr"`
+	Profiles                   string              `xml:"profiles,attr"`
+	XSI                        *string             `xml:"xsi,attr,omitempty"`
+	SCTE35                     *string             `xml:"scte35,attr,omitempty"`
+	XSISchemaLocation          *string             `xml:"schemaLocation,attr"`
+	ID                         *string             `xml:"id,attr"`
+	ProgramInformation         *ProgramInformation `xml:"ProgramInformation,omitempty"`
+	Period                     []Period            `xml:"Period,omitempty"`
 }
 
 // MPD represents root XML element for Marshal.
 type mpdMarshal struct {
-	XMLName                    xml.Name        `xml:"MPD"`
-	XSI                        *string         `xml:"xmlns:xsi,attr,omitempty"`
-	XMLNS                      *string         `xml:"xmlns,attr"`
-	XSISchemaLocation          *string         `xml:"xsi:schemaLocation,attr"`
-	ID                         *string         `xml:"id,attr"`
-	Type                       *string         `xml:"type,attr"`
-	PublishTime                *string         `xml:"publishTime,attr"`
-	MinimumUpdatePeriod        *string         `xml:"minimumUpdatePeriod,attr"`
-	AvailabilityStartTime      *string         `xml:"availabilityStartTime,attr"`
-	MediaPresentationDuration  *string         `xml:"mediaPresentationDuration,attr"`
-	MinBufferTime              *string         `xml:"minBufferTime,attr"`
-	MaxSegmentDuration         *string         `xml:"maxSegmentDuration,attr,omitempty"`
-	SuggestedPresentationDelay *string         `xml:"suggestedPresentationDelay,attr"`
-	TimeShiftBufferDepth       *string         `xml:"timeShiftBufferDepth,attr"`
-	Profiles                   string          `xml:"profiles,attr"`
-	SCTE35                     *string         `xml:"xmlns:scte35,attr,omitempty"`
-	Period                     []periodMarshal `xml:"Period,omitempty"`
+	XMLName                    xml.Name            `xml:"MPD"`
+	XSI                        *string             `xml:"xmlns:xsi,attr,omitempty"`
+	XMLNS                      *string             `xml:"xmlns,attr"`
+	XSISchemaLocation          *string             `xml:"xsi:schemaLocation,attr"`
+	ID                         *string             `xml:"id,attr"`
+	Type                       *string             `xml:"type,attr"`
+	PublishTime                *string             `xml:"publishTime,attr"`
+	MinimumUpdatePeriod        *string             `xml:"minimumUpdatePeriod,attr"`
+	AvailabilityStartTime      *string             `xml:"availabilityStartTime,attr"`
+	MediaPresentationDuration  *string             `xml:"mediaPresentationDuration,attr"`
+	MinBufferTime              *string             `xml:"minBufferTime,attr"`
+	MaxSegmentDuration         *string             `xml:"maxSegmentDuration,attr,omitempty"`
+	SuggestedPresentationDelay *string             `xml:"suggestedPresentationDelay,attr"`
+	TimeShiftBufferDepth       *string             `xml:"timeShiftBufferDepth,attr"`
+	Profiles                   string              `xml:"profiles,attr"`
+	SCTE35                     *string             `xml:"xmlns:scte35,attr,omitempty"`
+	ProgramInformation         *ProgramInformation `xml:"ProgramInformation,omitempty"`
+	Period                     []periodMarshal     `xml:"Period,omitempty"`
 }
 
 // Do not try to use encoding.TextMarshaler and encoding.TextUnmarshaler:
@@ -143,6 +145,11 @@ func (m *MPD) Encode() ([]byte, error) {
 // Decode parses MPD XML.
 func (m *MPD) Decode(b []byte) error {
 	return xml.Unmarshal(b, m)
+}
+
+// ProgramInformation - MPD Program info.
+type ProgramInformation struct {
+	Title string `xml:"Title,omitempty"`
 }
 
 // Period represents XSD's PeriodType.
@@ -296,6 +303,7 @@ func modifyMPD(mpd *MPD) *mpdMarshal {
 		SCTE35:                     copyobj.String(mpd.SCTE35),
 		XSISchemaLocation:          copyobj.String(mpd.XSISchemaLocation),
 		ID:                         copyobj.String(mpd.ID),
+		ProgramInformation:         copyProgramInformation(mpd.ProgramInformation),
 		Period:                     modifyPeriod(mpd.Period),
 	}
 }
@@ -316,6 +324,15 @@ func modifyPeriod(ps []Period) []periodMarshal {
 	}
 
 	return pms
+}
+
+func copyProgramInformation(p *ProgramInformation) *ProgramInformation {
+	if p == nil {
+		return nil
+	}
+	return &ProgramInformation{
+		Title: p.Title,
+	}
 }
 
 func modifyAdaptationSets(as []*AdaptationSet) []*adaptationSetMarshal {

--- a/mpd.go
+++ b/mpd.go
@@ -172,6 +172,12 @@ type AdaptationSet struct {
 	SubsegmentStartsWithSAP *uint64          `xml:"subsegmentStartsWithSAP,attr"`
 	Lang                    *string          `xml:"lang,attr"`
 	ContentProtections      []DRMDescriptor  `xml:"ContentProtection,omitempty"`
+	Par                     *string          `xml:"par,attr"`
+	MinWidth                *uint64          `xml:"minWidth,attr"`
+	MaxWidth                *uint64          `xml:"maxWidth,attr"`
+	MinHeight               *uint64          `xml:"minHeight,attr"`
+	MaxHeight               *uint64          `xml:"maxHeight,attr"`
+	MaxFrameRate            *string          `xml:"maxFrameRate,attr"`
 	Representations         []Representation `xml:"Representation,omitempty"`
 	Codecs                  *string          `xml:"codecs,attr"`
 }
@@ -186,6 +192,12 @@ type adaptationSetMarshal struct {
 	SubsegmentStartsWithSAP *uint64                 `xml:"subsegmentStartsWithSAP,attr"`
 	Lang                    *string                 `xml:"lang,attr"`
 	ContentProtections      []drmDescriptorMarshal  `xml:"ContentProtection,omitempty"`
+	Par                     *string                 `xml:"par,attr"`
+	MinWidth                *uint64                 `xml:"minWidth,attr"`
+	MaxWidth                *uint64                 `xml:"maxWidth,attr"`
+	MinHeight               *uint64                 `xml:"minHeight,attr"`
+	MaxHeight               *uint64                 `xml:"maxHeight,attr"`
+	MaxFrameRate            *string                 `xml:"maxFrameRate,attr"`
 	Representations         []representationMarshal `xml:"Representation,omitempty"`
 	Codecs                  *string                 `xml:"codecs,attr"`
 }
@@ -320,6 +332,12 @@ func modifyAdaptationSets(as []*AdaptationSet) []*adaptationSetMarshal {
 			MimeType:                a.MimeType,
 			SegmentAlignment:        a.SegmentAlignment,
 			StartWithSAP:            copyobj.UInt64(a.StartWithSAP),
+			Par:                     copyobj.String(a.Par),
+			MinWidth:                copyobj.UInt64(a.MinWidth),
+			MaxWidth:                copyobj.UInt64(a.MaxWidth),
+			MinHeight:               copyobj.UInt64(a.MinHeight),
+			MaxHeight:               copyobj.UInt64(a.MaxHeight),
+			MaxFrameRate:            copyobj.String(a.MaxFrameRate),
 			SubsegmentAlignment:     a.SubsegmentAlignment,
 			SubsegmentStartsWithSAP: copyobj.UInt64(a.SubsegmentStartsWithSAP),
 			Representations:         modifyRepresentations(a.Representations),

--- a/mpd.go
+++ b/mpd.go
@@ -185,6 +185,7 @@ type AdaptationSet struct {
 	MinHeight               *uint64          `xml:"minHeight,attr"`
 	MaxHeight               *uint64          `xml:"maxHeight,attr"`
 	MaxFrameRate            *string          `xml:"maxFrameRate,attr"`
+	Role                    *DescriptorType  `xml:"Role,omitempty"`
 	Representations         []Representation `xml:"Representation,omitempty"`
 	Codecs                  *string          `xml:"codecs,attr"`
 }
@@ -205,39 +206,40 @@ type adaptationSetMarshal struct {
 	MinHeight               *uint64                 `xml:"minHeight,attr"`
 	MaxHeight               *uint64                 `xml:"maxHeight,attr"`
 	MaxFrameRate            *string                 `xml:"maxFrameRate,attr"`
+	Role                    *DescriptorType         `xml:"Role,omitempty"`
 	Representations         []representationMarshal `xml:"Representation,omitempty"`
 	Codecs                  *string                 `xml:"codecs,attr"`
 }
 
 // Representation represents XSD's RepresentationType.
 type Representation struct {
-	ID                        *string                    `xml:"id,attr"`
-	Width                     *uint64                    `xml:"width,attr"`
-	Height                    *uint64                    `xml:"height,attr"`
-	SAR                       *string                    `xml:"sar,attr"`
-	FrameRate                 *string                    `xml:"frameRate,attr"`
-	Bandwidth                 *uint64                    `xml:"bandwidth,attr"`
-	AudioSamplingRate         *string                    `xml:"audioSamplingRate,attr"`
-	Codecs                    *string                    `xml:"codecs,attr"`
-	BaseURL                   *string                    `xml:"BaseURL,omitempty"`
-	ContentProtections        []DRMDescriptor            `xml:"ContentProtection,omitempty"`
-	SegmentTemplate           *SegmentTemplate           `xml:"SegmentTemplate,omitempty"`
-	AudioChannelConfiguration *AudioChannelConfiguration `xml:"AudioChannelConfiguration,omitempty"`
+	ID                        *string          `xml:"id,attr"`
+	Width                     *uint64          `xml:"width,attr"`
+	Height                    *uint64          `xml:"height,attr"`
+	SAR                       *string          `xml:"sar,attr"`
+	FrameRate                 *string          `xml:"frameRate,attr"`
+	Bandwidth                 *uint64          `xml:"bandwidth,attr"`
+	AudioSamplingRate         *string          `xml:"audioSamplingRate,attr"`
+	Codecs                    *string          `xml:"codecs,attr"`
+	BaseURL                   *string          `xml:"BaseURL,omitempty"`
+	ContentProtections        []DRMDescriptor  `xml:"ContentProtection,omitempty"`
+	SegmentTemplate           *SegmentTemplate `xml:"SegmentTemplate,omitempty"`
+	AudioChannelConfiguration *DescriptorType  `xml:"AudioChannelConfiguration,omitempty"`
 }
 
 type representationMarshal struct {
-	ID                        *string                    `xml:"id,attr"`
-	Width                     *uint64                    `xml:"width,attr"`
-	Height                    *uint64                    `xml:"height,attr"`
-	SAR                       *string                    `xml:"sar,attr"`
-	FrameRate                 *string                    `xml:"frameRate,attr"`
-	Bandwidth                 *uint64                    `xml:"bandwidth,attr"`
-	AudioSamplingRate         *string                    `xml:"audioSamplingRate,attr"`
-	Codecs                    *string                    `xml:"codecs,attr"`
-	BaseURL                   *string                    `xml:"BaseURL,omitempty"`
-	ContentProtections        []drmDescriptorMarshal     `xml:"ContentProtection,omitempty"`
-	SegmentTemplate           *SegmentTemplate           `xml:"SegmentTemplate,omitempty"`
-	AudioChannelConfiguration *AudioChannelConfiguration `xml:"AudioChannelConfiguration,omitempty"`
+	ID                        *string                `xml:"id,attr"`
+	Width                     *uint64                `xml:"width,attr"`
+	Height                    *uint64                `xml:"height,attr"`
+	SAR                       *string                `xml:"sar,attr"`
+	FrameRate                 *string                `xml:"frameRate,attr"`
+	Bandwidth                 *uint64                `xml:"bandwidth,attr"`
+	AudioSamplingRate         *string                `xml:"audioSamplingRate,attr"`
+	Codecs                    *string                `xml:"codecs,attr"`
+	BaseURL                   *string                `xml:"BaseURL,omitempty"`
+	ContentProtections        []drmDescriptorMarshal `xml:"ContentProtection,omitempty"`
+	SegmentTemplate           *SegmentTemplate       `xml:"SegmentTemplate,omitempty"`
+	AudioChannelConfiguration *DescriptorType        `xml:"AudioChannelConfiguration,omitempty"`
 }
 
 // Descriptor represents XSD's DescriptorType.
@@ -363,6 +365,7 @@ func modifyAdaptationSets(as []*AdaptationSet) []*adaptationSetMarshal {
 			MaxFrameRate:            copyobj.String(a.MaxFrameRate),
 			SubsegmentAlignment:     a.SubsegmentAlignment,
 			SubsegmentStartsWithSAP: copyobj.UInt64(a.SubsegmentStartsWithSAP),
+			Role:                    copyDescriptorType(a.Role),
 			Representations:         modifyRepresentations(a.Representations),
 			ContentProtections:      modifyContentProtections(a.ContentProtections),
 		}
@@ -386,20 +389,21 @@ func modifyRepresentations(rs []Representation) []representationMarshal {
 			SAR:                       copyobj.String(r.SAR),
 			ContentProtections:        modifyContentProtections(r.ContentProtections),
 			BaseURL:                   copyobj.String(r.BaseURL),
-			AudioChannelConfiguration: copyAudioChannelConfiguration(r.AudioChannelConfiguration),
+			AudioChannelConfiguration: copyDescriptorType(r.AudioChannelConfiguration),
 		}
 		rsm = append(rsm, representation)
 	}
 	return rsm
 }
 
-func copyAudioChannelConfiguration(acc *AudioChannelConfiguration) *AudioChannelConfiguration {
-	if acc == nil {
+func copyDescriptorType(dt *DescriptorType) *DescriptorType {
+	if dt == nil {
 		return nil
 	}
-	return &AudioChannelConfiguration{
-		SchemeIDURI: copyobj.String(acc.SchemeIDURI),
-		Value:       copyobj.String(acc.Value),
+	return &DescriptorType{
+		SchemeIDURI: copyobj.String(dt.SchemeIDURI),
+		Value:       copyobj.String(dt.Value),
+		ID:          copyobj.String(dt.ID),
 	}
 }
 
@@ -459,8 +463,9 @@ func modifyPssh(p *Pssh) *psshMarshal {
 	}
 }
 
-// AudioChannelConfiguration represents XSD's AudioChannelConfiguration type.
-type AudioChannelConfiguration struct {
+// DescriptorType - used in many places to represent data.
+type DescriptorType struct {
 	SchemeIDURI *string `xml:"schemeIdUri,attr"`
 	Value       *string `xml:"value,attr,omitempty"`
+	ID          *string `xml:"id,attr,omitempty"`
 }

--- a/mpd.go
+++ b/mpd.go
@@ -257,7 +257,7 @@ type drmDescriptorMarshal struct {
 	Pssh           *psshMarshal `xml:"cenc:pssh"`
 }
 
-// Pssh represents XSD's CencPsshType .
+// Pssh represents XSD's CencPsshType.
 type Pssh struct {
 	Cenc  *string `xml:"cenc,attr"`
 	Value *string `xml:",chardata"`
@@ -270,12 +270,18 @@ type psshMarshal struct {
 
 // SegmentTemplate represents XSD's SegmentTemplateType.
 type SegmentTemplate struct {
-	Timescale              *uint64            `xml:"timescale,attr"`
-	Media                  *string            `xml:"media,attr"`
-	Initialization         *string            `xml:"initialization,attr"`
-	StartNumber            *uint64            `xml:"startNumber,attr"`
-	PresentationTimeOffset *uint64            `xml:"presentationTimeOffset,attr"`
-	SegmentTimelineS       []SegmentTimelineS `xml:"SegmentTimeline>S,omitempty"`
+	Timescale              *uint64          `xml:"timescale,attr"`
+	Media                  *string          `xml:"media,attr"`
+	Initialization         *string          `xml:"initialization,attr"`
+	Duration               *uint64          `xml:"duration,attr"`
+	StartNumber            *uint64          `xml:"startNumber,attr"`
+	PresentationTimeOffset *uint64          `xml:"presentationTimeOffset,attr"`
+	SegmentTimeline        *SegmentTimeline `xml:"SegmentTimeline,omitempty"`
+}
+
+// SegmentTimeLine represent a SegmentTimeline node.
+type SegmentTimeline struct {
+	S []SegmentTimelineS `xml:"S,omitempty"`
 }
 
 // SegmentTimelineS represents XSD's SegmentTimelineType's inner S elements.
@@ -405,15 +411,19 @@ func copySegmentTemplate(st *SegmentTemplate) *SegmentTemplate {
 		Timescale:              copyobj.UInt64(st.Timescale),
 		Media:                  copyobj.String(st.Media),
 		Initialization:         copyobj.String(st.Initialization),
+		Duration:               copyobj.UInt64(st.Duration),
 		StartNumber:            copyobj.UInt64(st.StartNumber),
 		PresentationTimeOffset: copyobj.UInt64(st.PresentationTimeOffset),
-		SegmentTimelineS:       copySegmentTimelineS(st.SegmentTimelineS),
+		SegmentTimeline:        copySegmentTimeline(st.SegmentTimeline),
 	}
 }
 
-func copySegmentTimelineS(st []SegmentTimelineS) []SegmentTimelineS {
-	stm := make([]SegmentTimelineS, 0, len(st))
-	for _, s := range st {
+func copySegmentTimeline(st *SegmentTimeline) *SegmentTimeline {
+	if st == nil || len(st.S) == 0 {
+		return nil
+	}
+	stm := make([]SegmentTimelineS, 0, len(st.S))
+	for _, s := range st.S {
 		segmentTimelineS := SegmentTimelineS{
 			T: s.T,
 			D: s.D,
@@ -421,7 +431,7 @@ func copySegmentTimelineS(st []SegmentTimelineS) []SegmentTimelineS {
 		}
 		stm = append(stm, segmentTimelineS)
 	}
-	return stm
+	return &SegmentTimeline{S: stm}
 }
 
 func modifyContentProtections(ds []DRMDescriptor) []drmDescriptorMarshal {

--- a/mpd.go
+++ b/mpd.go
@@ -178,14 +178,15 @@ type AdaptationSet struct {
 	SubsegmentAlignment     ConditionalUint  `xml:"subsegmentAlignment,attr"`
 	SubsegmentStartsWithSAP *uint64          `xml:"subsegmentStartsWithSAP,attr"`
 	Lang                    *string          `xml:"lang,attr"`
-	ContentProtections      []DRMDescriptor  `xml:"ContentProtection,omitempty"`
 	Par                     *string          `xml:"par,attr"`
 	MinWidth                *uint64          `xml:"minWidth,attr"`
 	MaxWidth                *uint64          `xml:"maxWidth,attr"`
 	MinHeight               *uint64          `xml:"minHeight,attr"`
 	MaxHeight               *uint64          `xml:"maxHeight,attr"`
 	MaxFrameRate            *string          `xml:"maxFrameRate,attr"`
+	ContentProtections      []DRMDescriptor  `xml:"ContentProtection,omitempty"`
 	Role                    *DescriptorType  `xml:"Role,omitempty"`
+	SegmentTemplate         *SegmentTemplate `xml:"SegmentTemplate,omitempty"`
 	Representations         []Representation `xml:"Representation,omitempty"`
 	Codecs                  *string          `xml:"codecs,attr"`
 }
@@ -199,14 +200,15 @@ type adaptationSetMarshal struct {
 	SubsegmentAlignment     ConditionalUint         `xml:"subsegmentAlignment,attr"`
 	SubsegmentStartsWithSAP *uint64                 `xml:"subsegmentStartsWithSAP,attr"`
 	Lang                    *string                 `xml:"lang,attr"`
-	ContentProtections      []drmDescriptorMarshal  `xml:"ContentProtection,omitempty"`
 	Par                     *string                 `xml:"par,attr"`
 	MinWidth                *uint64                 `xml:"minWidth,attr"`
 	MaxWidth                *uint64                 `xml:"maxWidth,attr"`
 	MinHeight               *uint64                 `xml:"minHeight,attr"`
 	MaxHeight               *uint64                 `xml:"maxHeight,attr"`
 	MaxFrameRate            *string                 `xml:"maxFrameRate,attr"`
+	ContentProtections      []drmDescriptorMarshal  `xml:"ContentProtection,omitempty"`
 	Role                    *DescriptorType         `xml:"Role,omitempty"`
+	SegmentTemplate         *SegmentTemplate        `xml:"SegmentTemplate,omitempty"`
 	Representations         []representationMarshal `xml:"Representation,omitempty"`
 	Codecs                  *string                 `xml:"codecs,attr"`
 }
@@ -365,9 +367,10 @@ func modifyAdaptationSets(as []*AdaptationSet) []*adaptationSetMarshal {
 			MaxFrameRate:            copyobj.String(a.MaxFrameRate),
 			SubsegmentAlignment:     a.SubsegmentAlignment,
 			SubsegmentStartsWithSAP: copyobj.UInt64(a.SubsegmentStartsWithSAP),
-			Role:                    copyDescriptorType(a.Role),
-			Representations:         modifyRepresentations(a.Representations),
 			ContentProtections:      modifyContentProtections(a.ContentProtections),
+			Role:                    copyDescriptorType(a.Role),
+			SegmentTemplate:         copySegmentTemplate(a.SegmentTemplate),
+			Representations:         modifyRepresentations(a.Representations),
 		}
 		asm = append(asm, adaptationSet)
 	}

--- a/mpd.go
+++ b/mpd.go
@@ -163,6 +163,7 @@ type periodMarshal struct {
 
 // AdaptationSet represents XSD's AdaptationSetType.
 type AdaptationSet struct {
+	ContentType             string           `xml:"contentType,attr,omitempty"`
 	MimeType                string           `xml:"mimeType,attr"`
 	SegmentAlignment        ConditionalUint  `xml:"segmentAlignment,attr"`
 	StartWithSAP            *uint64          `xml:"startWithSAP,attr"`
@@ -176,6 +177,7 @@ type AdaptationSet struct {
 }
 
 type adaptationSetMarshal struct {
+	ContentType             string                  `xml:"contentType,attr,omitempty"`
 	MimeType                string                  `xml:"mimeType,attr"`
 	SegmentAlignment        ConditionalUint         `xml:"segmentAlignment,attr"`
 	StartWithSAP            *uint64                 `xml:"startWithSAP,attr"`
@@ -314,6 +316,7 @@ func modifyAdaptationSets(as []*AdaptationSet) []*adaptationSetMarshal {
 			BitstreamSwitching:      copyobj.Bool(a.BitstreamSwitching),
 			Codecs:                  copyobj.String(a.Codecs),
 			Lang:                    copyobj.String(a.Lang),
+			ContentType:             a.ContentType,
 			MimeType:                a.MimeType,
 			SegmentAlignment:        a.SegmentAlignment,
 			StartWithSAP:            copyobj.UInt64(a.StartWithSAP),

--- a/mpd_test.go
+++ b/mpd_test.go
@@ -64,7 +64,7 @@ func (s *MPDSuite) TestUnmarshalMarshalVodBaseURL(c *C) {
 func TestMPDEqual(t *testing.T) {
 	a := &MPD{}
 	b := &mpdMarshal{}
-	require.Equal(t, 17, reflect.ValueOf(a).Elem().NumField(),
+	require.Equal(t, 18, reflect.ValueOf(a).Elem().NumField(),
 		"model was updated, need to update this test and function modifyMPD")
 	require.Equal(t, reflect.ValueOf(a).Elem().NumField(), reflect.ValueOf(b).Elem().NumField(),
 		"MPD element count not equal mpdMarshal")

--- a/mpd_test.go
+++ b/mpd_test.go
@@ -64,7 +64,7 @@ func (s *MPDSuite) TestUnmarshalMarshalVodBaseURL(c *C) {
 func TestMPDEqual(t *testing.T) {
 	a := &MPD{}
 	b := &mpdMarshal{}
-	require.Equal(t, 16, reflect.ValueOf(a).Elem().NumField(),
+	require.Equal(t, 17, reflect.ValueOf(a).Elem().NumField(),
 		"model was updated, need to update this test and function modifyMPD")
 	require.Equal(t, reflect.ValueOf(a).Elem().NumField(), reflect.ValueOf(b).Elem().NumField(),
 		"MPD element count not equal mpdMarshal")

--- a/mpd_test.go
+++ b/mpd_test.go
@@ -91,7 +91,7 @@ func TestAdaptationSetEqual(t *testing.T) {
 func TestRepresentationEqual(t *testing.T) {
 	a := &Representation{}
 	b := &representationMarshal{}
-	require.Equal(t, 11, reflect.ValueOf(a).Elem().NumField(),
+	require.Equal(t, 12, reflect.ValueOf(a).Elem().NumField(),
 		"model was updated, need to update this test and function modifyRepresentations")
 	require.Equal(t, reflect.ValueOf(a).Elem().NumField(), reflect.ValueOf(b).Elem().NumField(),
 		"Representation element count not equal Representation")

--- a/mpd_test.go
+++ b/mpd_test.go
@@ -82,7 +82,7 @@ func TestPeriodEqual(t *testing.T) {
 func TestAdaptationSetEqual(t *testing.T) {
 	a := &AdaptationSet{}
 	b := &adaptationSetMarshal{}
-	require.Equal(t, 18, reflect.ValueOf(a).Elem().NumField(),
+	require.Equal(t, 19, reflect.ValueOf(a).Elem().NumField(),
 		"model was updated, need to update this test and function modifyAdaptationSets")
 	require.Equal(t, reflect.ValueOf(a).Elem().NumField(), reflect.ValueOf(b).Elem().NumField(),
 		"AdaptationSet element count not equal adaptationSetMarshal")

--- a/mpd_test.go
+++ b/mpd_test.go
@@ -99,7 +99,7 @@ func TestRepresentationEqual(t *testing.T) {
 
 func TestSegmentTemplateEqual(t *testing.T) {
 	a := &SegmentTemplate{}
-	require.Equal(t, 6, reflect.ValueOf(a).Elem().NumField(),
+	require.Equal(t, 7, reflect.ValueOf(a).Elem().NumField(),
 		"model was updated, need to update this test and function copySegmentTemplate")
 }
 

--- a/mpd_test.go
+++ b/mpd_test.go
@@ -1,6 +1,7 @@
 package mpd
 
 import (
+	"fmt"
 	"io/ioutil"
 	"reflect"
 	"strings"
@@ -17,6 +18,7 @@ type MPDSuite struct{}
 var _ = Suite(&MPDSuite{})
 
 func testUnmarshalMarshal(c *C, name string) {
+	fmt.Println(name)
 	expected, err := ioutil.ReadFile(name)
 	c.Assert(err, IsNil)
 
@@ -59,6 +61,10 @@ func (s *MPDSuite) TestUnmarshalMarshalLiveDelta161(c *C) {
 
 func (s *MPDSuite) TestUnmarshalMarshalVodBaseURL(c *C) {
 	testUnmarshalMarshal(c, "fixture_vod_with_base_url.mpd")
+}
+
+func (s *MPDSuite) TestUnmarshalMarshalLiveSimVod(c *C) {
+	testUnmarshalMarshal(c, "fixture_livesim_vod.mpd")
 }
 
 func TestMPDEqual(t *testing.T) {

--- a/mpd_test.go
+++ b/mpd_test.go
@@ -82,7 +82,7 @@ func TestPeriodEqual(t *testing.T) {
 func TestAdaptationSetEqual(t *testing.T) {
 	a := &AdaptationSet{}
 	b := &adaptationSetMarshal{}
-	require.Equal(t, 17, reflect.ValueOf(a).Elem().NumField(),
+	require.Equal(t, 18, reflect.ValueOf(a).Elem().NumField(),
 		"model was updated, need to update this test and function modifyAdaptationSets")
 	require.Equal(t, reflect.ValueOf(a).Elem().NumField(), reflect.ValueOf(b).Elem().NumField(),
 		"AdaptationSet element count not equal adaptationSetMarshal")

--- a/mpd_test.go
+++ b/mpd_test.go
@@ -82,7 +82,7 @@ func TestPeriodEqual(t *testing.T) {
 func TestAdaptationSetEqual(t *testing.T) {
 	a := &AdaptationSet{}
 	b := &adaptationSetMarshal{}
-	require.Equal(t, 10, reflect.ValueOf(a).Elem().NumField(),
+	require.Equal(t, 11, reflect.ValueOf(a).Elem().NumField(),
 		"model was updated, need to update this test and function modifyAdaptationSets")
 	require.Equal(t, reflect.ValueOf(a).Elem().NumField(), reflect.ValueOf(b).Elem().NumField(),
 		"AdaptationSet element count not equal adaptationSetMarshal")

--- a/mpd_test.go
+++ b/mpd_test.go
@@ -82,7 +82,7 @@ func TestPeriodEqual(t *testing.T) {
 func TestAdaptationSetEqual(t *testing.T) {
 	a := &AdaptationSet{}
 	b := &adaptationSetMarshal{}
-	require.Equal(t, 11, reflect.ValueOf(a).Elem().NumField(),
+	require.Equal(t, 17, reflect.ValueOf(a).Elem().NumField(),
 		"model was updated, need to update this test and function modifyAdaptationSets")
 	require.Equal(t, reflect.ValueOf(a).Elem().NumField(), reflect.ValueOf(b).Elem().NumField(),
 		"AdaptationSet element count not equal adaptationSetMarshal")


### PR DESCRIPTION
Added all elements needed to decode and encode the basic VoD asset MPD which is used in DASH-IF livesim.
https://livesim.dashif.org/dash/vod/testpic_2s/Manifest.mpd

An extra level was needed to be inserted to handle that SegmentTimeline is not used in this MPD.

The two issues #6 and #7 are related to this PR.

To be able to represent all output from DASH-IF livesim, many more elements need to be introduced, and Period at the top-level of the MPD must be a slice to support multi-period DASH.